### PR TITLE
🚑 pv & pv-claim 추가

### DIFF
--- a/k8s/dev-room-k8s/templates/cmd-server/cmd-server-deployment.yaml
+++ b/k8s/dev-room-k8s/templates/cmd-server/cmd-server-deployment.yaml
@@ -38,4 +38,4 @@ spec:
             name: {{ .Values.cmd_server_name }}-config
         - name: data
           persistentVolumeClaim:
-            claimName: {{ .Values.pv_name }}-claim
+            claimName: {{ .Values.node_name }}-claim

--- a/k8s/dev-room-k8s/templates/storage/dev-room-pv-claim.yaml
+++ b/k8s/dev-room-k8s/templates/storage/dev-room-pv-claim.yaml
@@ -1,11 +1,14 @@
+{{- range $pv:= .Values.pv_group }}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.pv_name }}-claim
+  name: {{ $pv.name }}-claim
 spec:
   accessModes:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.pv_capacity }}
+      storage: {{ $.Values.pv_capacity }}
   storageClassName: ""
+{{- end }}

--- a/k8s/dev-room-k8s/templates/storage/dev-room-pv.yaml
+++ b/k8s/dev-room-k8s/templates/storage/dev-room-pv.yaml
@@ -1,10 +1,12 @@
+{{- range $pv:= .Values.pv_group }}
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Values.pv_name }}
+  name: {{ $pv.name }}
 spec:
   capacity:
-    storage:  {{ .Values.pv_capacity }}
+    storage:  {{ $.Values.pv_capacity }}
   accessModes:
     - ReadWriteMany
   local:
@@ -17,4 +19,5 @@ spec:
           - key: storage
             operator: In
             values:
-              - {{ .Values.pv_name }}
+              - {{ $.Values.node_name }}
+{{- end }}

--- a/k8s/dev-room-k8s/values.yaml
+++ b/k8s/dev-room-k8s/values.yaml
@@ -10,12 +10,18 @@ service_type: LoadBalancer
 # name of cmd server
 cmd_server_name: dev-room-cmd-server
 # main persistent volume
-pv_name: dev-room-pv
+node_name: dev-room-pv
+pv_group: 
+  - name: dev-room-pv
+  - name: ta-data
+  - name: student-data
+
 pv_capacity: 500Mi
 pv_host_folder_name: dev-room
 pv_student_folder_name: student
 pv_class_folder_name: class
 pv_ta_folder_name: ta
+
 # test class template
 student_mount_path: "/home"
 


### PR DESCRIPTION
## ta-data, student-data pv 및 claim 추가

k8s deploy에서, 동일한 pv claim에 대해 여러 볼륨을 마운트하는게 불가능 한 것으로 추정됩니다. default-scheduler  Successfully assigned default 에서 더 이상 진행되지 않아 자세한 원인은 모르지만, 동일한 pv claim을 사용할때 만 해당 문제가 발생합니다.   

이 때문에 학생의 컨테이너에 학생의 private 폴더와 수업의 readonly public 폴더의 동시 마운트가 불가하여서, 추가로 pv와 claim을 추가했습니다. 편리성을 위해 helm의 range로 적용하였습니다.
