### PR TITLE
Hotfix/student route

### DIFF
--- a/backend/src/main/java/com/devlatte/devroom/k8s/controller/user/ProfessorController.java
+++ b/backend/src/main/java/com/devlatte/devroom/k8s/controller/user/ProfessorController.java
@@ -45,17 +45,13 @@ public class ProfessorController extends K8sControllerBase {
 
         String className = jsonObject.get("className").getAsString();
         JsonArray studentIdsArray = jsonObject.getAsJsonArray("studentIds");
-        List<String> studentIds = new ArrayList<>();
-        for (JsonElement element : studentIdsArray) studentIds.add(element.getAsString());
+        String studentId  = jsonObject.get("studentId").getAsString();
 
-        return handleResponse(classApi.delete(className, studentIds));
+        return handleResponse(classApi.delete(className, studentId));
     }
     @GetMapping(value = "/class/{id}/pod", produces = "application/json")
     public ResponseEntity<String> getPodByLabel(@PathVariable String id) {
         return handleResponse(podApi.getInfo("professor_id", "id-"+id));
     }
-//    @GetMapping(value = "/class/all/pod", produces = "application/json")
-//    public ResponseEntity<String> getPodAll() {
-//        return handleResponse(podApi.getInfo("all", null));
-//    }
+
 }

--- a/backend/src/main/java/com/devlatte/devroom/k8s/controller/user/StudentController.java
+++ b/backend/src/main/java/com/devlatte/devroom/k8s/controller/user/StudentController.java
@@ -17,17 +17,17 @@ public class StudentController extends K8sControllerBase {
     private final ServiceApi serviceApi;
     private final DeployApi deployApi;
 
-    @GetMapping(value = "/pod/id/{id}", produces = "application/json")
+    @GetMapping(value = "/pod/{id}", produces = "application/json")
     public ResponseEntity<String> getPodByLabel(@PathVariable String id) {
         return handleResponse(podApi.getInfo("student_id", "id-"+id));
     }
 
-    @GetMapping(value = "/service/id/{id}", produces = "application/json")
+    @GetMapping(value = "/service/{id}", produces = "application/json")
     public ResponseEntity<String> getServiceByLabel(@PathVariable String id) {
         return handleResponse(serviceApi.getInfo("student_id", "id-"+id));
     }
 
-    @GetMapping(value = "/deploy/id/{id}", produces = "application/json")
+    @GetMapping(value = "/deploy/{id}", produces = "application/json")
     public ResponseEntity<String> getDeploymentsByLabel( @PathVariable String id) {
         return handleResponse(deployApi.getInfo("student_id", "id-"+id));
     }

--- a/backend/src/main/java/com/devlatte/devroom/security/SecurityConfig.java
+++ b/backend/src/main/java/com/devlatte/devroom/security/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                         .requestMatchers("/", "/error").permitAll()
                         // 보안을 위해 k8s에 직접적으로 요청하는 API는 전부 deny
                         .requestMatchers("/core/**").denyAll()
-                        .requestMatchers("/pod/id/{id}","/service/id/{id}","/deploy/id/{id}").access(new WebExpressionAuthorizationManager("hasAuthority('ID_'+#id) and hasAuthority('ROLE_Student')"))
+                        .requestMatchers("/pod/{id}","/service/{id}","/deploy/{id}").access(new WebExpressionAuthorizationManager("hasAuthority('ID_'+#id) and hasAuthority('ROLE_Student')"))
                         .requestMatchers("/class/{id}/**").access(new WebExpressionAuthorizationManager("hasAuthority('ID_'+#id) and hasAuthority('ROLE_Professor')"))
                         .anyRequest().authenticated();
                 })


### PR DESCRIPTION
학생 계정의 라우트에서 id를 제거하였습니다.

- /pod/id/{id} -> /pod/{id}
-  /deploy/id/{id} -> /deploy/{id}
-  /service/id/{id} -> /service/{id}

교수계정의 라우트에서 request 양식을 수정하였습니다.
- /class/{id}/delete -> 리스트를 string으로 변환