### PR TITLE
🚑 cpu_limit 제한 해제

### DIFF
--- a/backend/src/main/java/com/devlatte/devroom/k8s/api/core/DeployApi.java
+++ b/backend/src/main/java/com/devlatte/devroom/k8s/api/core/DeployApi.java
@@ -133,7 +133,7 @@ public class DeployApi extends K8sApiBase {
                         .withImage(image)
                         .withResources(new ResourceRequirementsBuilder()
                         .addToRequests("cpu", new Quantity(cpuReq))
-                        .addToLimits("cpu", new Quantity(cpuLimit))
+//                        .addToLimits("cpu", new Quantity(cpuLimit))
                         .addToRequests("memory", new Quantity(memReq)) // RAM request
                         .addToLimits("memory", new Quantity(memLimit))     // RAM limit
                         .build())


### PR DESCRIPTION
cpu limit 제한을 제거했습니다. 하한과 우선순위에 해당하는 request는 여전히 남아있습니다.